### PR TITLE
Added `classes` property to provide static CSS classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Vue.use(VuetifyToast, {
 	y: 'bottom', // default
 	color: 'info', // default
 	icon: 'info',
-	classes: 'body-2',
+	classes: [
+		'body-2'
+	],
 	timeout: 3000, // default
 	dismissable: true, // default
 	autoHeight: false, // default

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Vue.use(VuetifyToast, {
 	y: 'bottom', // default
 	color: 'info', // default
 	icon: 'info',
+	classes: 'body-2',
 	timeout: 3000, // default
 	dismissable: true, // default
 	autoHeight: false, // default

--- a/src/Toast.vue
+++ b/src/Toast.vue
@@ -46,7 +46,7 @@
         type: String
       },
       classes: {
-        type: String
+        type: [ String, Object, Array ]
       },
       message: {
         type: String

--- a/src/Toast.vue
+++ b/src/Toast.vue
@@ -11,6 +11,7 @@
       :vertical = "vertical"
       v-model="active"
       class="application"
+      :class="classes"
       @click="dismiss"
   >
     <v-icon
@@ -42,6 +43,9 @@
         default: 'info'
       },
       icon: {
+        type: String
+      },
+      classes: {
         type: String
       },
       message: {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,7 +16,7 @@ export interface VuetifyToastObject {
   y?: string
   color?: string
   icon?: string
-  classes? : string
+  classes? : string | object | Array<object | string>
   timeout?: number
   dismissable?: boolean
   autoHeight? : boolean

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,7 @@ export interface VuetifyToastObject {
   y?: string
   color?: string
   icon?: string
+  classes? : string
   timeout?: number
   dismissable?: boolean
   autoHeight? : boolean


### PR DESCRIPTION
This would permit to integrate easily the component in different environments.

I was adding `vuetify-toast-snackbar` (what a **nice** plugin !) to a personal web application, when I discovered that the Vuetify default style for toasts was not graphically what I expected for.

Being able to supply such a thing would solve my problem and my web app would look so clean ! 😄 