### PR TITLE
Append the snackbar to the Vuetify application wrapper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ function init(Vue, globalOptions = {}) {
   function createCmp(options) {
     let component = new Vue(Toast)
     Object.assign(component, Vue.prototype[property].globalOptions, options)
-    document.body.appendChild(component.$mount().$el)
+    document.querySelector('.application, .v-application').appendChild(cmp.$mount().$el)
 
     return component
   }


### PR DESCRIPTION
Vuetify has released version 2.0 and they have changed how the global styled are scoped.
All the global colors (warning, success, info, error, ...) are scoped under .v-application and not under the root selector anymore.

Because your plugin appends the snackbar to the body directly and not to the Vuetify application wrapper, all the snackbars will stay black. I changed that one line of code so the snackbar will get appended to the application wrapper.

In Vue1 to .application
In Vue2 to .v-application