### PR TITLE
remove auto-height prop

### DIFF
--- a/src/Toast.vue
+++ b/src/Toast.vue
@@ -6,7 +6,6 @@
     :top="y === 'top'"
     :left="x === 'left'"
     :right="x === 'right'"
-    :auto-height = "autoHeight"
     :multi-line = "multiLine"
     :vertical = "vertical"
     v-model="active"
@@ -68,10 +67,6 @@ export default {
     dismissable: {
       type: Boolean,
       default: true
-    },
-    autoHeight: {
-      type: Boolean,
-      default: false
     },
     multiLine: {
       type: Boolean,


### PR DESCRIPTION
auto-height props has been removed in vuetify V2
https://vuetifyjs.com/en/components/snackbars#snackbars
![image](https://user-images.githubusercontent.com/25365069/62114812-49483280-b2af-11e9-9050-b9b5361ca8df.png)
