### PR TITLE
Adds attach container to plugin initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Vue.use(VuetifyToast, {
 		}
 	},
 	property: '$toast' // default
-})
+},
+'body') // default
 ```
 
 ### Vue loader (e.g. Nuxt.js)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import Toast from './Toast.vue'
 
-function init(Vue, globalOptions = {}) {
+function init(Vue, globalOptions = {}, attach = 'body') {
   let cmp = null
   const queue = []
   const property = globalOptions.property || '$toast'
@@ -15,7 +15,7 @@ function init(Vue, globalOptions = {}) {
     }
 
     Object.assign(component, componentOptions)
-    document.body.appendChild(component.$mount().$el)
+    document.querySelector(attach).appendChild(component.$mount().$el)
 
     return component
   }


### PR DESCRIPTION
- With this it's now possible to define a container to which the snackbar should be mounted to. The default is the `body` element.