### PR TITLE
Adds attach container to plugin initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Vue.use(VuetifyToast, {
 			color: 'purple'
 		}
 	},
-	property: '$toast' // default
+	property: '$toast', // default
+	attach: 'body' // default
 })
 ```
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,6 +29,7 @@ export interface VuetifyToastObject {
   queueable?: boolean
   slot?: Array<any>
   shorts?: any
+  attach: string
 }
 
 interface VuetifyToastShow {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ function init(Vue, globalOptions = {}) {
   let cmp = null
   const queue = []
   const property = globalOptions.property || '$toast'
+  const attach = globalOptions.attach || 'body'
 
   function createCmp(options) {
     const component = new Vue(Toast)
@@ -15,7 +16,7 @@ function init(Vue, globalOptions = {}) {
     }
 
     Object.assign(component, componentOptions)
-    document.body.appendChild(component.$mount().$el)
+    document.querySelector(attach).appendChild(component.$mount().$el)
 
     return component
   }


### PR DESCRIPTION
With this it's now possible to define a container to which the snackbar should be mounted to. The default is the `body` element.