### PR TITLE
Update installation snippet to support vuetify-loader ^1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ Vue.use(Vuetify, {
   }
 })
 
-Vue.use(VuetifyToast)
+const veutifyObj = new Vuetify({
+    theme: { dark: true },
+});
+
+Vue.use(VuetifyToast, { $vuetify: veutifyObj.framework })
+
+export default veutifyObj;
 ```
 
 ### Call


### PR DESCRIPTION
New vuetify loader breaks the package resulting in error
```vue.js:634 [Vue warn]: Error in render: "TypeError: Cannot read property 'bar' of undefined"```

This change in readme accounts for that.

resolves #42